### PR TITLE
[YOLOv3] Calculate ignore mask for each example within a batch individually

### DIFF
--- a/YOLO/tensorflow/utils.py
+++ b/YOLO/tensorflow/utils.py
@@ -35,8 +35,8 @@ def broadcast_iou(box_a, box_b):
     https://github.com/dmlc/gluon-cv/blob/c3dd20d4b1c1ef8b7d381ad2a7d04a68c5fa1221/gluoncv/nn/bbox.py#L206
 
     inputs:
-    box1: a tensor full of boxes, eg. (B, N, 4)
-    box2: another tensor full of boxes, eg. (B, M, 4)
+    box_a: a tensor full of boxes, eg. (B, N, 4), box is in x1y1x2y2
+    box_b: another tensor full of boxes, eg. (B, M, 4)
     """
 
     # (B, N, 1, 4)
@@ -57,13 +57,13 @@ def broadcast_iou(box_a, box_b):
 
     # (B, N, M, 1)
     left = tf.math.maximum(al, bl)
-    right = tf.math.maximum(ar, br)
+    right = tf.math.minimum(ar, br)
     top = tf.math.maximum(at, bt)
-    bot = tf.math.maximum(ab, bb)
+    bot = tf.math.minimum(ab, bb)
 
     # (B, N, M, 1)
-    iw = right - left
-    ih = bot - top
+    iw = tf.clip_by_value(right - left, 0, 1)
+    ih = tf.clip_by_value(bot - top, 0, 1)
     i = iw * ih
 
     # (B, N, M, 1)

--- a/YOLO/tensorflow/utils.py
+++ b/YOLO/tensorflow/utils.py
@@ -28,50 +28,53 @@ def xywh_to_y1x1y2x2(box):
     return y_box
 
 
-def broadcast_iou(box1, box2):
+def broadcast_iou(box_a, box_b):
     """
-    calculate iou between one box1iction box and multiple box2 box in a broadcast way
+    calculate iou between box_a and multiple box_b in a broadcast way.
+    Used this implementation as reference: 
+    https://github.com/dmlc/gluon-cv/blob/c3dd20d4b1c1ef8b7d381ad2a7d04a68c5fa1221/gluoncv/nn/bbox.py#L206
 
     inputs:
-    box1: a tensor full of boxes, eg. (3, 4)
-    box2: another tensor full of boxes, eg. (3, 4)
+    box1: a tensor full of boxes, eg. (B, N, 4)
+    box2: another tensor full of boxes, eg. (B, M, 4)
     """
 
-    # assert one dimension in order to mix match box1 and box2
-    # eg:
-    # box1 -> (3, 1, 4)
-    # box2 -> (1, 3, 4)
-    box1 = tf.expand_dims(box1, -2)
-    box2 = tf.expand_dims(box2, 0)
+    # (B, N, 1, 4)
+    box_a = tf.expand_dims(box_a, -2)
+    # (B, 1, M, 4)
+    box_b = tf.expand_dims(box_b, -3)
+    # (B, N, M, 4)
+    new_shape = tf.broadcast_dynamic_shape(tf.shape(box_a), tf.shape(box_b))
 
-    # derive the union of shape to broadcast
-    # eg. new_shape -> (3, 3, 4)
-    new_shape = tf.broadcast_dynamic_shape(tf.shape(box1), tf.shape(box2))
+    # (B, N, M, 4)
+    # (B, N, M, 4)
+    box_a = tf.broadcast_to(box_a, new_shape)
+    box_b = tf.broadcast_to(box_b, new_shape)
 
-    # broadcast (duplicate) box1 and box2 so that
-    # each box2 has one box1 matched correspondingly
-    # box1: (3, 3, 4)
-    # box2: (3, 3, 4)
-    box1 = tf.broadcast_to(box1, new_shape)
-    box2 = tf.broadcast_to(box2, new_shape)
+    # (B, N, M, 1)
+    al, at, ar, ab = tf.split(box_a, 4, -1)
+    bl, bt, br, bb = tf.split(box_b, 4, -1)
 
-    # minimum xmax - maximum xmin is the width of intersection.
-    # but has to be greater or equal to 0
-    interserction_w = tf.maximum(
-        tf.minimum(box1[..., 2], box2[..., 2]) - tf.maximum(
-            box1[..., 0], box2[..., 0]), 0)
-    # minimum ymax - maximum ymin is the height of intersection.
-    # but has to be greater or equal to 0
-    interserction_h = tf.maximum(
-        tf.minimum(box1[..., 3], box2[..., 3]) - tf.maximum(
-            box1[..., 1], box2[..., 1]), 0)
-    intersection_area = interserction_w * interserction_h
-    box1_area = (box1[..., 2] - box1[..., 0]) * \
-        (box1[..., 3] - box1[..., 1])
-    box2_area = (box2[..., 2] - box2[..., 0]) * \
-        (box2[..., 3] - box2[..., 1])
-    # intersection over union
-    return intersection_area / (box1_area + box2_area - intersection_area)
+    # (B, N, M, 1)
+    left = tf.math.maximum(al, bl)
+    right = tf.math.maximum(ar, br)
+    top = tf.math.maximum(at, bt)
+    bot = tf.math.maximum(ab, bb)
+
+    # (B, N, M, 1)
+    iw = right - left
+    ih = bot - top
+    i = iw * ih
+
+    # (B, N, M, 1)
+    area_a = (ar - al) * (ab - at)
+    area_b = (br - bl) * (bb - bt)
+    union = area_a + area_b - i
+
+    # (B, N, M)
+    iou = tf.squeeze(i / (union + 1e-7), axis=-1)
+
+    return iou
 
 
 def binary_cross_entropy(logits, labels):

--- a/YOLO/tensorflow/yolov3.py
+++ b/YOLO/tensorflow/yolov3.py
@@ -450,7 +450,7 @@ class YoloLoss(object):
         true_box = tf.sort(true_box, axis=1, direction="DESCENDING")
         # (None, 100, 4)
         # only use maximum 100 boxes per groundtruth to calcualte IOU, otherwise
-        # GPU emory comsumption would explose for a matrix like (16, 52*52*3, 52*52*3, 4)
+        # GPU emory comsumption would explode for a matrix like (16, 52*52*3, 52*52*3, 4)
         true_box = true_box[:, 0:100, :]
         # (None, 507, 4)
         pred_box = tf.reshape(pred_box, [pred_box_shape[0], -1, 4])

--- a/YOLO/tensorflow/yolov3.py
+++ b/YOLO/tensorflow/yolov3.py
@@ -434,10 +434,11 @@ class YoloLoss(object):
                                                            obj_loss)
 
     def calc_ignore_mask(self, true_obj, true_box, pred_box):
-
+        
         def calc_example_ignore_mask(inputs):
             """
-            calcualte ignore mask for each example in current batch
+            calcualte ignore mask for each example in current batch.
+            thanks kelvinkoh0308 for catching this bug here: https://github.com/ethanyanjiali/deep-vision/issues/6
             """
             example_true_obj, example_true_box, example_pred_box = inputs
             # eg. true_obj (13, 13, 3, 1)


### PR DESCRIPTION
A fix for Issue https://github.com/ethanyanjiali/deep-vision/issues/6

This is a bug when batch size > 1 because all pred boxes and true boxes within same batch will be mingled together to calculate ignore mask, which is wrong. The right way is to calculate IOU for boxes within same example.

By theory, this bug would cause some truth boxes being mistakenly ignored, which is like an over-regularization that could lead to under-fitting. I'm currently running a new training with batch 16 to see if this would result in higher mAP of the model.

~~TODO: I feel like there might be a vectorized way to do this and love to do so. but I'm using tf.map_fn for now to fix this bug asap.~~